### PR TITLE
Remove deprecated default_executable from gemspec

### DIFF
--- a/NAME.gemspec
+++ b/NAME.gemspec
@@ -39,7 +39,6 @@ Gem::Specification.new do |s|
 
   ## If your gem includes any executables, list them here.
   s.executables = ["name"]
-  s.default_executable = 'name'
 
   ## Specify any RDoc options here. You'll want to add your README and
   ## LICENSE files to the extra_rdoc_files list.


### PR DESCRIPTION
This gets rid of the warning thrown by RubyGems 1.8 and later.
